### PR TITLE
Resolution Center updates

### DIFF
--- a/package.json
+++ b/package.json
@@ -5,7 +5,9 @@
   "license": "MIT",
   "contributors": [
     "Dexter St Pierre <dexter.stpierre.dev@gmail.com>",
-    "John Gellert <gellertjm@gmail.com>"
+    "John Gellert <gellertjm@gmail.com>",
+    "Nate Notermann <nate.notermann@gmail.com>",
+    "Liz Kerber <lizkerber12@gmail.com>"
   ],
   "engines": {
     "node": "16.x"

--- a/src/app/app.module.ts
+++ b/src/app/app.module.ts
@@ -40,10 +40,7 @@ import { MatSelectModule } from "@angular/material/select";
 import { MatFormFieldModule } from "@angular/material/form-field";
 import { MatMenuModule } from "@angular/material/menu";
 import { MatSlideToggleModule } from '@angular/material/slide-toggle'
-import {
-  MatLegacyRadioModule as MatRadioModule,
-  MAT_LEGACY_RADIO_DEFAULT_OPTIONS as MAT_RADIO_DEFAULT_OPTIONS,
-} from "@angular/material/legacy-radio";
+import { MatRadioModule, MAT_RADIO_DEFAULT_OPTIONS } from '@angular/material/radio';
 
 // added with angular material
 import { BrowserAnimationsModule } from "@angular/platform-browser/animations";

--- a/src/app/app/dialog/dialog.component.ts
+++ b/src/app/app/dialog/dialog.component.ts
@@ -1,5 +1,5 @@
 import { Component, OnInit, Inject } from "@angular/core";
-import { MatLegacyDialogRef as MatDialogRef, MAT_LEGACY_DIALOG_DATA as MAT_DIALOG_DATA } from "@angular/material/legacy-dialog";
+import { MatDialogRef, MAT_DIALOG_DATA } from "@angular/material/dialog";
 
 @Component({
   selector: "app-dialog",

--- a/src/app/app/directory/directory.component.html
+++ b/src/app/app/directory/directory.component.html
@@ -4,7 +4,7 @@
   </div>
 
   <div class="sideways-nav-bar">
-    <nav mat-tab-nav-bar color="primary">
+    <nav mat-tab-nav-bar color="primary" [tabPanel]="tabPanel">
       <a mat-tab-link *ngFor="let link of directoryLinks"
       (click)="activeLink = link.name"
       [active]="activeLink == link.name"
@@ -17,6 +17,8 @@
   </div>
   <p>You can search, add, edit or delete units on this page.</p>
   <div>
-    <router-outlet></router-outlet>
+    <mat-tab-nav-panel #tabPanel>
+      <router-outlet></router-outlet>
+    </mat-tab-nav-panel>
   </div>  
 </div>

--- a/src/app/app/directory/directory.module.ts
+++ b/src/app/app/directory/directory.module.ts
@@ -8,7 +8,7 @@ import { RouterModule, Routes } from '@angular/router';
 import { AuthGuardService } from 'app/services/auth-guard.service';
 // -- css elements
 import { BrowserAnimationsModule } from '@angular/platform-browser/animations';
-import { MatLegacyTabsModule as MatTabsModule } from "@angular/material/legacy-tabs";
+import { MatTabsModule } from '@angular/material/tabs';
 import { MatTableModule } from '@angular/material/table';
 import { MatButtonModule } from '@angular/material/button';
 import { MatDialogModule } from '@angular/material/dialog';

--- a/src/app/app/rules/rules.component.ts
+++ b/src/app/app/rules/rules.component.ts
@@ -1,7 +1,7 @@
 import { Component, OnInit } from "@angular/core";
 import { DataService } from "../../services/data.service";
 import { UserService } from "../../services/user.service";
-import { MatLegacyDialog as MatDialog } from "@angular/material/legacy-dialog";
+import { MatDialog } from "@angular/material/dialog";
 import { DialogComponent } from "../dialog/dialog.component";
 import { Subscription } from "rxjs";
 import { Rule } from "./rule.model";

--- a/src/app/app/users-center/users-center.component.html
+++ b/src/app/app/users-center/users-center.component.html
@@ -3,7 +3,7 @@
         User Center
     </h3>
     <div class="sideways-nav-bar">
-        <nav mat-tab-nav-bar color="primary">
+        <nav mat-tab-nav-bar color="primary" [tabPanel]="tabPanel">
             <a mat-tab-link *ngFor="let link of usersCenterLinks"
             (click)="activeLink = link.name"
             [active]="activeLink == link.name"
@@ -15,6 +15,8 @@
         </nav>
     </div>
     <div>
-        <router-outlet></router-outlet>
+        <mat-tab-nav-panel #tabPanel>
+            <router-outlet></router-outlet>
+        </mat-tab-nav-panel>
     </div>
 </div>

--- a/src/app/app/users-center/users-center.module.ts
+++ b/src/app/app/users-center/users-center.module.ts
@@ -8,7 +8,7 @@ import { RouterModule, Routes } from '@angular/router';
 import { AuthGuardService } from 'app/services/auth-guard.service';
 // -- css elements
 import { BrowserAnimationsModule } from '@angular/platform-browser/animations';
-import { MatLegacyTabsModule as MatTabsModule } from "@angular/material/legacy-tabs";
+import { MatTabsModule } from '@angular/material/tabs';
 import { MatTableModule } from '@angular/material/table';
 import { MatButtonModule } from '@angular/material/button';
 import { MatDialogModule } from '@angular/material/dialog';

--- a/src/app/app/users-center/users-view/users-view.component.ts
+++ b/src/app/app/users-center/users-view/users-view.component.ts
@@ -1,7 +1,7 @@
 import { Component, OnInit, ViewChild } from "@angular/core";
 import { Subscription } from "rxjs";
-import { MatLegacyTable as MatTable } from "@angular/material/legacy-table";
-import { MatLegacyDialog as MatDialog } from "@angular/material/legacy-dialog";
+import { MatTable } from "@angular/material/table";
+import { MatDialog } from "@angular/material/dialog";
 import { UserService } from "../../../services/user.service";  // -- SERVICE
 import { UsersCenterService } from "../../../services/users-center.service";  // -- SERVICE
 import { Router } from "@angular/router";

--- a/src/app/resolution-center/create-objection/create-objection.component.ts
+++ b/src/app/resolution-center/create-objection/create-objection.component.ts
@@ -43,13 +43,6 @@ export class CreateObjectionComponent implements OnInit {
     });
   }
 
-  public submit(objection) {
-    console.log('SUBMIT:', objection);
-    this.resolutionCenterService
-      .submitObjection(objection)
-      .subscribe((response) => {});
-  }
-
   onSubmit() {
     // -- Everything we are passing to the backend
     var objection = {
@@ -60,7 +53,9 @@ export class CreateObjectionComponent implements OnInit {
     // this.resetForm();
     this.resolutionCenterService
       .submitObjection(objection)
-      .subscribe((response) => {});
+      .subscribe((response) => {
+        this.resetForm();
+      });
   }
 
   onCancel() {

--- a/src/app/resolution-center/create-objection/create-objection.component.ts
+++ b/src/app/resolution-center/create-objection/create-objection.component.ts
@@ -2,6 +2,7 @@ import { Component, OnInit } from "@angular/core";
 import { ResolutionCenterService } from "../resolution-center.service";
 import { UserService } from "../../services/user.service";
 import { UntypedFormControl, UntypedFormGroup, Validators } from "@angular/forms";
+import { Router } from '@angular/router';
 
 @Component({
   selector: "app-create-objection",
@@ -18,7 +19,8 @@ export class CreateObjectionComponent implements OnInit {
 
   constructor(
     private resolutionCenterService: ResolutionCenterService,
-    private userService: UserService
+    private userService: UserService,
+    private router: Router,
   ) {}
 
   get againstControl() {
@@ -50,11 +52,12 @@ export class CreateObjectionComponent implements OnInit {
       against: this.againstControl.value,
       comment: this.commentControl.value,
     };
-    // this.resetForm();
+
     this.resolutionCenterService
       .submitObjection(objection)
       .subscribe((response) => {
         this.resetForm();
+        this.router.navigate(['/home/resolution-center/inbox']);
       });
   }
 

--- a/src/app/resolution-center/inbox/inbox.component.css
+++ b/src/app/resolution-center/inbox/inbox.component.css
@@ -7,3 +7,8 @@ table {
   border-radius: 5px;
   box-shadow: 0 2px 2px 0 rgba(0, 0, 0, 0.2), 0 0px 5px 0 rgba(0, 0, 0, 0.19);
 }
+
+.has-voted-check {
+  font-size: 2em;
+  color: green;
+}

--- a/src/app/resolution-center/inbox/inbox.component.html
+++ b/src/app/resolution-center/inbox/inbox.component.html
@@ -11,7 +11,7 @@
   <ng-container matColumnDef="submitted-against">
     <th mat-header-cell *matHeaderCellDef>Submitted Against</th>
     <td mat-cell *matCellDef="let objection">
-      {{ objection?.submittedAgainstUser?.units[0]?.addressLineOne }}
+      {{ objection?.submittedAgainstUser?.units[0]?.addressLineOne === null ? 'N/A' : objection?.submittedAgainstUser?.units[0]?.addressLineOne }}
     </td>
   </ng-container>
 

--- a/src/app/resolution-center/inbox/inbox.component.html
+++ b/src/app/resolution-center/inbox/inbox.component.html
@@ -1,8 +1,9 @@
 <table mat-table [dataSource]="objections" class="mat-elevation-z8" #inboxTable>
+  
   <!-- Submitted By Column -->
   <ng-container matColumnDef="submitted-by">
     <th mat-header-cell *matHeaderCellDef>Submitted By</th>
-    <td mat-cell *matCellDef="let objection">
+    <td mat-cell *matCellDef="let objection" (click)="openDetails(objection)">
       {{ objection?.submittedByUser?.units[0]?.addressLineOne }}
     </td>
   </ng-container>
@@ -10,7 +11,7 @@
   <!-- Submitted Against Column -->
   <ng-container matColumnDef="submitted-against">
     <th mat-header-cell *matHeaderCellDef>Submitted Against</th>
-    <td mat-cell *matCellDef="let objection">
+    <td mat-cell *matCellDef="let objection" (click)="openDetails(objection)">
       {{ objection?.submittedAgainstUser?.units[0]?.addressLineOne === null ? 'N/A' : objection?.submittedAgainstUser?.units[0]?.addressLineOne }}
     </td>
   </ng-container>
@@ -18,7 +19,9 @@
   <!-- Submitted On Column -->
   <ng-container matColumnDef="submitted-on">
     <th mat-header-cell *matHeaderCellDef>Submitted On</th>
-    <td mat-cell *matCellDef="let objection">{{ objection.createdAt | date: 'medium' }}</td>
+    <td mat-cell *matCellDef="let objection" (click)="openDetails(objection)">
+      {{ objection.createdAt | date: 'medium' }}
+    </td>
   </ng-container>
 
   <ng-container matColumnDef="vote-button">
@@ -37,7 +40,9 @@
         </button>
       </ng-container>
       <ng-container *ngIf="objection?.votes[0]?.objection_id !== null">
-        <p class="has-voted-check">&#10004;</p>
+        <div (click)="openDetails(objection)">
+          <p class="has-voted-check">&#10004;</p>
+        </div>
       </ng-container>
     </td>
   </ng-container>

--- a/src/app/resolution-center/inbox/inbox.component.html
+++ b/src/app/resolution-center/inbox/inbox.component.html
@@ -24,16 +24,21 @@
   <ng-container matColumnDef="vote-button">
     <th mat-header-cell *matHeaderCellDef>Vote</th>
     <td mat-cell *matCellDef="let objection">
-      <button
-        [id]="objection.id"
-        mat-raised-button
-        color="accent"
-        class="btn btn-primary float-right"
-        type="submit"
-        (click)="selectObjection(objection); openDialog(objection)"
-      >
-        Vote
-      </button>
+      <ng-container *ngIf="objection?.votes[0]?.objection_id === null">
+        <button
+          [id]="objection.id"
+          mat-raised-button
+          color="accent"
+          class="btn btn-primary float-right"
+          type="submit"
+          (click)="selectObjection(objection); openDialog(objection)"
+        >
+          Vote
+        </button>
+      </ng-container>
+      <ng-container *ngIf="objection?.votes[0]?.objection_id !== null">
+        <p class="has-voted-check">&#10004;</p>
+      </ng-container>
     </td>
   </ng-container>
 

--- a/src/app/resolution-center/inbox/inbox.component.ts
+++ b/src/app/resolution-center/inbox/inbox.component.ts
@@ -58,5 +58,8 @@ export class InboxComponent implements OnInit {
     const voteDialogRef = this.voteDialog.open(VoteDialogComponent, {
       data: objection,
     });
+    voteDialogRef.afterClosed().subscribe(() => {
+      this.init();
+    });
   }
 }

--- a/src/app/resolution-center/inbox/inbox.component.ts
+++ b/src/app/resolution-center/inbox/inbox.component.ts
@@ -16,7 +16,7 @@ export class InboxComponent implements OnInit {
 
   public objections: Objection[] = [];
 
-  public currentObjection;
+  public currentObjection: any;
 
   public displayedColumns: string[] = [
     "submitted-by",
@@ -42,8 +42,8 @@ export class InboxComponent implements OnInit {
   private init() {
     this.resolutionCenterService
       .getInbox().subscribe((response) => {
-        console.log('response:', response);
-        console.log('response.objections:', response.objections);
+        // console.log('response:', response);
+        // console.log('response.objections:', response.objections);
 
         this.objections = response.objections;
       });

--- a/src/app/resolution-center/inbox/inbox.component.ts
+++ b/src/app/resolution-center/inbox/inbox.component.ts
@@ -5,6 +5,7 @@ import { Objection } from "../models/objection";
 import { MatTable } from "@angular/material/table";
 import { MatDialog } from "@angular/material/dialog";
 import { VoteDialogComponent } from "../vote-dialog/vote-dialog.component";
+import { ObjectionDetailsComponent } from "../objection-details/objection-details.component";
 
 @Component({
   selector: "app-inbox",
@@ -28,7 +29,8 @@ export class InboxComponent implements OnInit {
   constructor(
     private resolutionCenterService: ResolutionCenterService,
     private userService: UserService,
-    public voteDialog: MatDialog
+    public voteDialog: MatDialog,
+    public detailDialog: MatDialog
   ) {}
 
   ngOnInit() {
@@ -54,12 +56,30 @@ export class InboxComponent implements OnInit {
   }
 
   openDialog(objection: Objection) {
-    console.log('obj:', objection);
+    // console.log('obj:', objection);
     const voteDialogRef = this.voteDialog.open(VoteDialogComponent, {
       data: objection,
     });
     voteDialogRef.afterClosed().subscribe(() => {
       this.init();
     });
+  }
+
+  openDetails(objection: any): void {
+    // console.log('objection:', objection);
+    if (objection.votes[0]?.objection_id > 0) {
+      const detailDialogRef = this.detailDialog.open(ObjectionDetailsComponent, {
+        width: '800px',
+        data: { 
+          objection: objection,
+          source: 'inbox'
+        },
+      });
+      detailDialogRef.afterClosed().subscribe(() => {
+        this.init();
+      });
+    } else {
+      return;
+    }
   }
 }

--- a/src/app/resolution-center/inbox/inbox.component.ts
+++ b/src/app/resolution-center/inbox/inbox.component.ts
@@ -2,8 +2,8 @@ import { Component, OnInit, ViewChild } from "@angular/core";
 import { ResolutionCenterService } from "../resolution-center.service";
 import { UserService } from "../../services/user.service";
 import { Objection } from "../models/objection";
-import { MatLegacyTable as MatTable } from "@angular/material/legacy-table";
-import { MatLegacyDialog as MatDialog } from "@angular/material/legacy-dialog";
+import { MatTable } from "@angular/material/table";
+import { MatDialog } from "@angular/material/dialog";
 import { VoteDialogComponent } from "../vote-dialog/vote-dialog.component";
 
 @Component({
@@ -46,7 +46,6 @@ export class InboxComponent implements OnInit {
         console.log('response.objections:', response.objections);
 
         this.objections = response.objections;
-        // this.objections = response;
       });
   }
 

--- a/src/app/resolution-center/models/objection.ts
+++ b/src/app/resolution-center/models/objection.ts
@@ -13,6 +13,12 @@ export class Objection {
     id: number;
     units: { addressLineOne: string }[];
   };
+  result: boolean | null;
+  closedAt: Date | null;
+  closesAt: Date;
+  votes: {
+    objection_id: number;
+  }[] | null;
 
   // TODO: show user how much time is left to vote
   // timeLeftToVote() {

--- a/src/app/resolution-center/objection-details/objection-details.component.html
+++ b/src/app/resolution-center/objection-details/objection-details.component.html
@@ -1,0 +1,13 @@
+<div class="objection-details-main-div">
+    <h2 mat-dialog-title>{{ headerText }}</h2>
+    <mat-dialog-content>
+        <p><strong>Submitted by:</strong> {{ data.objection.submittedByUser?.units[0]?.addressLineOne }}</p>
+        <p><strong>Submitted against:</strong> {{ data.objection.submittedAgainstUser?.units[0]?.addressLineOne || 'N/A' }}</p>
+        <p><strong>Comment:</strong> {{ data.objection.comment }}</p>
+        <p><strong>Result:</strong> {{ resultText }}</p>
+        <p><strong>{{ closeLabel }}</strong> {{ closeDate | date: 'medium' }}</p>
+    </mat-dialog-content>
+    <mat-dialog-actions align="end">
+        <button mat-button (click)="close()">Close</button>
+    </mat-dialog-actions>
+</div>

--- a/src/app/resolution-center/objection-details/objection-details.component.spec.ts
+++ b/src/app/resolution-center/objection-details/objection-details.component.spec.ts
@@ -1,0 +1,28 @@
+/* tslint:disable:no-unused-variable */
+import { async, ComponentFixture, TestBed } from '@angular/core/testing';
+import { By } from '@angular/platform-browser';
+// import { DebugElement } from '@angular/core';
+
+import { ObjectionDetailsComponent } from './objection-details.component';
+
+describe('ObjectionDetailsComponent', () => {
+    let component: ObjectionDetailsComponent;
+    let fixture: ComponentFixture<ObjectionDetailsComponent>;
+
+    beforeEach(async(() => {
+        TestBed.configureTestingModule({
+        declarations: [ ObjectionDetailsComponent ]
+        })
+        .compileComponents();
+    }));
+
+    beforeEach(() => {
+        fixture = TestBed.createComponent(ObjectionDetailsComponent);
+        component = fixture.componentInstance;
+        fixture.detectChanges();
+    });
+
+    it('should create', () => {
+        expect(component).toBeTruthy();
+    });
+});

--- a/src/app/resolution-center/objection-details/objection-details.component.ts
+++ b/src/app/resolution-center/objection-details/objection-details.component.ts
@@ -1,0 +1,41 @@
+import { Component, Inject } from '@angular/core';
+import { MAT_DIALOG_DATA, MatDialogRef } from '@angular/material/dialog';
+
+@Component({
+selector: 'app-objection-details',
+    templateUrl: './objection-details.component.html',
+    styleUrls: ['./objection-details.component.css']
+})
+export class ObjectionDetailsComponent {
+    headerText: string;
+    resultText: string;
+    closeLabel: string;
+    closeDate: string;
+
+    constructor(
+        public dialogRef: MatDialogRef<ObjectionDetailsComponent>,
+        @Inject(MAT_DIALOG_DATA) public data: any
+    ) {
+        this.headerText = data.source === 'inbox'
+        ? 'You have already voted' 
+        : 'Resolved Motion';
+
+        this.resultText = data.objection.closedAt === null
+        ? 'In progress'
+        : data.objection.result
+            ? 'Approved'
+            : 'Disapproved';
+
+        this.closeLabel = data.objection.closedAt === null 
+        ? 'Closes at:' 
+        : 'Closed at:';
+
+        this.closeDate = data.objection.closedAt === null
+        ? data.objection.closesAt
+        : data.objection.closedAt;
+    }
+
+    close(): void {
+        this.dialogRef.close();
+    }
+}

--- a/src/app/resolution-center/objection/objection.component.ts
+++ b/src/app/resolution-center/objection/objection.component.ts
@@ -42,14 +42,15 @@ export class ObjectionComponent implements OnInit {
   }
 
   vote(approved) {
-    this.resolutionCenterService.submitVote(1, 1).subscribe(
-      (response) => {
-        this.canVote = false;
-        this.message = "Your vote has been recorded. Thank you for voting";
-      },
-      (error) => {
-        this.message = "A server error has occurred. Please try again later";
-      }
-    );
+    console.log('need to fix this function!');
+    // this.resolutionCenterService.submitVote(1, 1).subscribe(
+    //   (response) => {
+    //     this.canVote = false;
+    //     this.message = "Your vote has been recorded. Thank you for voting";
+    //   },
+    //   (error) => {
+    //     this.message = "A server error has occurred. Please try again later";
+    //   }
+    // );
   }
 }

--- a/src/app/resolution-center/past-objections/past-objections.component.html
+++ b/src/app/resolution-center/past-objections/past-objections.component.html
@@ -29,9 +29,7 @@
         mat-raised-button
         color="accent"
         class="btn btn-primary float-right"
-        type="submit"
-        [routerLink]="['documents']"
-        (click)="viewObjection(objection.id)"
+        (click)="openDetails(objection)"
       >
         View
       </button>

--- a/src/app/resolution-center/past-objections/past-objections.component.ts
+++ b/src/app/resolution-center/past-objections/past-objections.component.ts
@@ -1,8 +1,9 @@
 import { Component, OnInit } from '@angular/core';
-
+import { MatDialog } from '@angular/material/dialog';
+import { ActivatedRoute, Router } from '@angular/router';
 import { ResolutionCenterService } from '../resolution-center.service';
 import { UserService } from '../../services/user.service';
-import { ActivatedRoute, Router } from '@angular/router';
+import { ObjectionDetailsComponent } from '../objection-details/objection-details.component';
 
 @Component({
   selector: 'app-past-objections',
@@ -23,7 +24,8 @@ export class PastObjectionsComponent implements OnInit {
     private resolutionCenterService: ResolutionCenterService,
     private userService: UserService,
     private router: Router,
-    public route: ActivatedRoute
+    public route: ActivatedRoute,
+    public detailDialog: MatDialog
     ) {}
 
   ngOnInit() {
@@ -34,9 +36,14 @@ export class PastObjectionsComponent implements OnInit {
   }
 
    // <a [routerLink]="../objection/{{objection.id}}">View</a>
-   viewObjection(objectionId: number) {
-    this.router.navigate([`objection/${objectionId}`], {
-      relativeTo: this.route,
+   openDetails(objection: any): void {
+    // console.log('past-objections component, objection:', objection);
+    this.detailDialog.open(ObjectionDetailsComponent, {
+      width: '800px',
+      data: {
+        objection: objection, 
+        source: 'past-objections'
+      }
     });
   }
 

--- a/src/app/resolution-center/resolution-center.component.html
+++ b/src/app/resolution-center/resolution-center.component.html
@@ -3,7 +3,7 @@
     Resolution Center
   </h3>
   <div class="sideways-nav-bar">
-    <nav mat-tab-nav-bar color="primary">
+    <nav mat-tab-nav-bar color="primary" [tabPanel]="tabPanel">
       <a mat-tab-link *ngFor="let link of resolutionCenterLinks"
       (click)="activeLink = link.name"
       [active]="activeLink == link.name"
@@ -13,8 +13,8 @@
         {{link.name}}
       </a>
     </nav>
-  </div>
-  <div>
-    <router-outlet></router-outlet>
+    <mat-tab-nav-panel #tabPanel>
+      <router-outlet></router-outlet>
+    </mat-tab-nav-panel>
   </div>
 </div>

--- a/src/app/resolution-center/resolution-center.component.ts
+++ b/src/app/resolution-center/resolution-center.component.ts
@@ -1,5 +1,5 @@
 import { Component, OnInit } from "@angular/core";
-import { Router } from "@angular/router";
+import { ActivatedRoute, Router } from "@angular/router";
 import { DataService } from "../services/data.service";
 import { UserService } from "../services/user.service";
 import { Subscription } from "rxjs";
@@ -18,7 +18,8 @@ export class ResolutionCenterComponent implements OnInit {
   constructor(
     private dataService: DataService,
     private userService: UserService,
-    private router: Router
+    private router: Router,
+    private route: ActivatedRoute
   ) {
     this.resolutionCenterLinks = [];
     // this.resolutionCenterLinks = [
@@ -45,6 +46,24 @@ export class ResolutionCenterComponent implements OnInit {
   ngOnInit() {
     this.resolutionCenterLinks = [];
     this.listenForEvents();
+
+    // set active tab based on url
+    this.router.events.subscribe(() => {
+      switch (this.getCurrentUrl()) {
+        case "/home/resolution-center/inbox":
+          this.activeLink = "Open Motions (Inbox)";
+          break;
+        case "/home/resolution-center/past":
+          this.activeLink = "Past Motions";
+          break;
+        case "/home/resolution-center/objection/create":
+          this.activeLink = "File Motion";
+          break;
+        default:
+          this.activeLink = "";
+          break;
+      }
+    })
   }
 
   getCurrentUrl(): string {

--- a/src/app/resolution-center/resolution-center.module.ts
+++ b/src/app/resolution-center/resolution-center.module.ts
@@ -17,15 +17,15 @@ import { RouterModule, Routes } from "@angular/router";
 import { AuthGuardService } from "../services/auth-guard.service";
 import { BrowserAnimationsModule } from "@angular/platform-browser/animations";
 
-import { MatLegacyTabsModule as MatTabsModule } from "@angular/material/legacy-tabs";
-import { MatLegacyTableModule as MatTableModule } from "@angular/material/legacy-table";
-import { MatLegacyButtonModule as MatButtonModule } from "@angular/material/legacy-button";
-import { MatLegacyDialogModule as MatDialogModule } from "@angular/material/legacy-dialog";
-import { MatLegacyRadioModule as MatRadioModule } from "@angular/material/legacy-radio";
+import { MatTabsModule } from "@angular/material/tabs";
+import { MatTableModule } from "@angular/material/table";
+import { MatButtonModule } from "@angular/material/button";
+import { MatDialogModule } from "@angular/material/dialog";
+import { MatRadioModule } from '@angular/material/radio';
 import { MatIconModule } from "@angular/material/icon";
-import { MatLegacySelectModule as MatSelectModule } from "@angular/material/legacy-select";
-import { MatLegacyFormFieldModule as MatFormFieldModule } from "@angular/material/legacy-form-field";
-import { MatLegacyInputModule as MatInputModule } from "@angular/material/legacy-input";
+import { MatSelectModule } from "@angular/material/select";
+import { MatFormFieldModule } from "@angular/material/form-field";
+import { MatInputModule } from "@angular/material/input";
 
 export const ResolutionCenterRoutes: Routes = [
   {

--- a/src/app/resolution-center/resolution-center.module.ts
+++ b/src/app/resolution-center/resolution-center.module.ts
@@ -12,6 +12,7 @@ import { OutboxComponent } from "./outbox/outbox.component";
 import { ResolutionCenterService } from "./resolution-center.service";
 import { PastObjectionsComponent } from "./past-objections/past-objections.component";
 import { VoteDialogComponent } from "./vote-dialog/vote-dialog.component";
+import { ObjectionDetailsComponent } from "./objection-details/objection-details.component";
 
 import { RouterModule, Routes } from "@angular/router";
 import { AuthGuardService } from "../services/auth-guard.service";
@@ -74,6 +75,7 @@ export const ResolutionCenterRoutes: Routes = [
     OutboxComponent,
     PastObjectionsComponent,
     VoteDialogComponent,
+    ObjectionDetailsComponent,
   ],
   providers: [ResolutionCenterService],
 })

--- a/src/app/resolution-center/resolution-center.service.ts
+++ b/src/app/resolution-center/resolution-center.service.ts
@@ -77,11 +77,14 @@ export class ResolutionCenterService {
     );
   }
 
+  // function is unused
   public getOutbox(): Observable<{ objections: any[] }> {
     const endpoint = "/api/outbox"
+    console.log('getOutbox() runs');
     return this.http.get<{ objections: any[] }>( BACKEND_URL + endpoint, {
-      params: new HttpParams() .set( "associationId", sessionStorage.getItem("associationId").toString())
-      .set("userId", 4), //sessionStorage.getItem("userId").toString()),
+      params: new HttpParams()
+        .set("associationId", sessionStorage.getItem("associationId"))
+        .set("userId", sessionStorage.getItem("userId"))
     });
   }
 

--- a/src/app/resolution-center/resolution-center.service.ts
+++ b/src/app/resolution-center/resolution-center.service.ts
@@ -56,12 +56,13 @@ export class ResolutionCenterService {
   }
 
   // -- POST Route 
-  public submitObjection(objection) {
+  public submitObjection(objection: any) {
     const endpoint = "/api/objections"
-
-    console.log('OBJECTION:', objection);
-    return this.http.post( BACKEND_URL + endpoint, { objection },);
-      // { params: new HttpParams() .set( "associationId", sessionStorage.getItem("associationId").toString()) .set( "userId", 1 ),} 
+    // console.log('objection:', objection); // organizationId, against, comment
+    return this.http.post( 
+      BACKEND_URL + endpoint, 
+      { objection }
+    );
   }
 
   public submitVote(vote: number, objectionId: number) {

--- a/src/app/resolution-center/vote-dialog/vote-dialog.component.ts
+++ b/src/app/resolution-center/vote-dialog/vote-dialog.component.ts
@@ -1,33 +1,36 @@
 import { Component, OnInit, Inject } from "@angular/core";
-import { MatLegacyDialogRef as MatDialogRef, MAT_LEGACY_DIALOG_DATA as MAT_DIALOG_DATA } from "@angular/material/legacy-dialog";
+import { MatDialogRef, MAT_DIALOG_DATA } from "@angular/material/dialog";
 import { Objection } from "../models/objection";
 import { ResolutionCenterService } from "../resolution-center.service";
-import { UntypedFormControl, UntypedFormGroup, Validators } from '@angular/forms';
+import { FormBuilder, UntypedFormGroup, Validators } from '@angular/forms';
 
 @Component({
   selector: "app-vote-dialog",
   templateUrl: "./vote-dialog.component.html",
   styleUrls: ["./vote-dialog.component.scss"],
 })
+
 export class VoteDialogComponent implements OnInit {
   objectionData: Objection;
-
-
-
-  voteForm = new UntypedFormGroup ({
-    voteControl: new UntypedFormControl(null, Validators.required)
-  });
+  selectedVote: number;
+  voteForm: UntypedFormGroup;
 
   constructor(
     private resolutionCenterService: ResolutionCenterService,
     public voteDialogRef: MatDialogRef<VoteDialogComponent>,
+    private fb: FormBuilder,
     @Inject(MAT_DIALOG_DATA) public objVoteData: any
-  ) {}
+  ) {
+    this.voteForm = this.fb.group({
+      voteControl: [null, [Validators.required]]
+    });
+  }
 
   ngOnInit() {
     this.objectionData = this.objVoteData;
     this.voteForm.statusChanges.subscribe(() => {
       console.log(this.voteForm.get("voteControl").value);
+      this.selectedVote = Number(this.voteForm.get("voteControl").value);
     })
     this.voteDialogRef.afterClosed().subscribe(() => {
       this.voteForm.reset();
@@ -35,10 +38,9 @@ export class VoteDialogComponent implements OnInit {
   }
 
   onSubmit(objectionId: number) {
-    var vote = this.voteForm.get("voteControl").value;
     this.resolutionCenterService
       .submitVote(
-        vote,
+        this.selectedVote,
         objectionId,
       )
       .subscribe((response) => {});

--- a/src/app/services/user.service.ts
+++ b/src/app/services/user.service.ts
@@ -88,8 +88,8 @@ export class UserService {
               now.getTime() + expiresInDuration * 1000
             );
             this.saveAuthData(token, expirationDate);
-            // this.saveUserData(response.user.id); // -- don't save userID
-            this.saveUserData(response.user.name);  // -- save users firstName instead
+            this.saveUserData(response.user.userId);  
+            // this.saveUserData(response.user.name );  // -- save users firstName instead of id
             this.getLoggedInUser();
             // this.setSelectedAssociation({id: response.associationId, name: response.a});
             this.saveUserAssociationData(response.association.id, response.association.name);
@@ -186,9 +186,8 @@ export class UserService {
     };
   }
 
-  private saveUserData(userName: string) {
-    // sessionStorage.setItem("userId", userId); // -- don't use this. Don't save User ID like this.
-    sessionStorage.setItem("userName", userName ); // -- use this. Use firstName instead (don't send or save User Id)
+  private saveUserData(userId: number) {
+    sessionStorage.setItem("userId", userId.toString());
   }
 
   private saveUserAssociationData(associationId: number, associationName: string) {


### PR DESCRIPTION
- Bug fix: Save vote
- When voting, Approve/Disapprove radios show as selected
- Display “N/A” when a motion is not against a specific unit
- If a user has already voted on an objection/motion, display a check mark instead of the Vote button
- Bug fix: resolve accessibility issue present on a few navigation panels ("A mat-tab-nav-panel must be specified via [tabPanel].")
- Bug fix: Save a new motion/objection
- Bug fix: Security on viewing past motions
- Take user back to Inbox after submitting a new motion
- Display active tab within Resolution Center
- Built Objection Details pop-up, which opens when user clicks on an already-voted-on item in Resolution Center → Inbox, and when user clicks on Resolution Center → Past Motions → View button